### PR TITLE
Add cypher file extension

### DIFF
--- a/src/main/java/com/neueda4j/intellij/plugin/cypher/file/CypherFileTypeFactory.java
+++ b/src/main/java/com/neueda4j/intellij/plugin/cypher/file/CypherFileTypeFactory.java
@@ -13,6 +13,6 @@ public class CypherFileTypeFactory extends FileTypeFactory {
 
     @Override
     public void createFileTypes(@NotNull FileTypeConsumer fileTypeConsumer) {
-        fileTypeConsumer.consume(CypherFileType.INSTANCE, "cyp");
+        fileTypeConsumer.consume(CypherFileType.INSTANCE, "cyp;cypher");
     }
 }


### PR DESCRIPTION
For request #12: Add cypher file extension to supported extensions. Default is still "cyp".